### PR TITLE
setup: changed twisted version to 18.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ setup(name='stratum',
       url='http://blog.bitcoin.cz/stratum',
       packages=['stratum',],
       zip_safe=False,
-      install_requires=['twisted', 'ecdsa', 'autobahn',]
+      install_requires=['twisted==18.4.0', 'ecdsa', 'autobahn',]
      )


### PR DESCRIPTION
With the twisted newer version, it will give an error of headers. By downgrading to twisted 18.4.0 it can be removed as the stratum is written about that time.